### PR TITLE
Update BurpExtender.java

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -26,7 +26,7 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener {
         processBuilder.command(cmdParam);
         try {
             Process process = processBuilder.start();
-            int exitVal = process.waitFor();
+            int exitVal = process.exitValue();
             if(exitVal != 0)
                 semgrepInstalled = false;
         }catch(Exception e){


### PR DESCRIPTION
Changed from `waitFor()` to `exitValue()`, do to the hang issues that come from the waitFor function.

Ref: 
* https://www.tutorialspoint.com/java/lang/process_waitfor.htm
* https://stackoverflow.com/questions/5483830/process-waitfor-never-returns
* https://stackoverflow.com/questions/29746304/processbuilder-and-process-waitfor-how-long-does-it-wait